### PR TITLE
msm8960: display: Force including kernel intermediates

### DIFF
--- a/msm8084/Android.mk
+++ b/msm8084/Android.mk
@@ -1,6 +1,10 @@
-display-hals := libgralloc libcopybit liblight libvirtual
+display-hals := libgralloc libcopybit libvirtual
 display-hals += libhwcomposer liboverlay libqdutils libexternal libqservice
 display-hals += libmemtrack
+ifneq ($(TARGET_PROVIDES_LIBLIGHT),true)
+display-hals += liblight
+endif
+
 ifeq ($(call is-vendor-board-platform,QCOM),true)
     include $(call all-named-subdir-makefiles,$(display-hals))
 else

--- a/msm8226/Android.mk
+++ b/msm8226/Android.mk
@@ -1,6 +1,10 @@
-display-hals := libgralloc libcopybit liblight libvirtual
+display-hals := libgralloc libcopybit libvirtual
 display-hals += libhwcomposer liboverlay libqdutils libexternal libqservice
 display-hals += libmemtrack
+ifneq ($(TARGET_PROVIDES_LIBLIGHT),true)
+display-hals += liblight
+endif
+
 ifeq ($(call is-vendor-board-platform,QCOM),true)
     include $(call all-named-subdir-makefiles,$(display-hals))
 else

--- a/msm8909/Android.mk
+++ b/msm8909/Android.mk
@@ -1,6 +1,10 @@
-display-hals := libgralloc libgenlock libcopybit liblight
+display-hals := libgralloc libgenlock libcopybit
 display-hals += libhwcomposer liboverlay libqdutils libhdmi libqservice
 display-hals += libmemtrack
+ifneq ($(TARGET_PROVIDES_LIBLIGHT),true)
+display-hals += liblight
+endif
+
 ifeq ($(call is-vendor-board-platform,QCOM),true)
     include $(call all-named-subdir-makefiles,$(display-hals))
 else

--- a/msm8960/Android.mk
+++ b/msm8960/Android.mk
@@ -1,6 +1,10 @@
-display-hals := libgralloc libgenlock libcopybit liblight
+display-hals := libgralloc libgenlock libcopybit
 display-hals += libhwcomposer liboverlay libqdutils libexternal libqservice
 display-hals += libmemtrack
+ifneq ($(TARGET_PROVIDES_LIBLIGHT),true)
+display-hals += liblight
+endif
+
 ifeq ($(call is-vendor-board-platform,QCOM),true)
     include $(call all-named-subdir-makefiles,$(display-hals))
 else

--- a/msm8960/libcopybit/Android.mk
+++ b/msm8960/libcopybit/Android.mk
@@ -25,6 +25,7 @@ LOCAL_MODULE                  := copybit.$(TARGET_BOARD_PLATFORM)
 LOCAL_MODULE_PATH             := $(TARGET_OUT_SHARED_LIBRARIES)/hw
 LOCAL_MODULE_TAGS             := optional
 LOCAL_C_INCLUDES              := $(common_includes) $(kernel_includes)
+LOCAL_C_INCLUDES              += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr/include
 LOCAL_SHARED_LIBRARIES        := $(common_libs) libdl libmemalloc
 LOCAL_CFLAGS                  := $(common_flags) -DLOG_TAG=\"qdcopybit\"
 LOCAL_ADDITIONAL_DEPENDENCIES := $(common_deps)

--- a/msm8960/libcopybit/copybit_c2d.cpp
+++ b/msm8960/libcopybit/copybit_c2d.cpp
@@ -1387,8 +1387,8 @@ static int blit_copybit(
 {
     int status = COPYBIT_SUCCESS;
     struct copybit_context_t* ctx = (struct copybit_context_t*)dev;
-    struct copybit_rect_t dr = { 0, 0, dst->w, dst->h };
-    struct copybit_rect_t sr = { 0, 0, src->w, src->h };
+    struct copybit_rect_t dr = { 0, 0, (int)dst->w, (int)dst->h };
+    struct copybit_rect_t sr = { 0, 0, (int)src->w, (int)src->h };
     pthread_mutex_lock(&ctx->wait_cleanup_lock);
     status = stretch_copybit_internal(dev, dst, src, &dr, &sr, region, false);
     pthread_mutex_unlock(&ctx->wait_cleanup_lock);


### PR DESCRIPTION
Another dependency, however should be okay with $(kernel_includes), but not in my case (broke the damn build xD).
Just as a fail safe, bring the C_INCLUDES so that makefile always includes 'usr/include' directory.