### PR TITLE
vold: Fix fsck on public volumes

### DIFF
--- a/PrivateVolume.cpp
+++ b/PrivateVolume.cpp
@@ -105,7 +105,7 @@ status_t PrivateVolume::doMount() {
     }
 
     if (mFsType == "ext4") {
-        int res = ext4::Check(mDmDevPath, mPath);
+        int res = ext4::Check(mDmDevPath, mPath, true);
         if (res == 0 || res == 1) {
             LOG(DEBUG) << getId() << " passed filesystem check";
         } else {
@@ -119,7 +119,7 @@ status_t PrivateVolume::doMount() {
         }
 
     } else if (mFsType == "f2fs") {
-        int res = f2fs::Check(mDmDevPath);
+        int res = f2fs::Check(mDmDevPath, true);
         if (res == 0) {
             LOG(DEBUG) << getId() << " passed filesystem check";
         } else {

--- a/PublicVolume.cpp
+++ b/PublicVolume.cpp
@@ -131,9 +131,9 @@ status_t PublicVolume::doMount() {
     if (mFsType == "exfat") {
         ret = exfat::Check(mDevPath);
     } else if (mFsType == "ext4") {
-        ret = ext4::Check(mDevPath, mRawPath);
+        ret = ext4::Check(mDevPath, mRawPath, false);
     } else if (mFsType == "f2fs") {
-        ret = f2fs::Check(mDevPath);
+        ret = f2fs::Check(mDevPath, false);
     } else if (mFsType == "ntfs") {
         ret = ntfs::Check(mDevPath);
     } else if (mFsType == "vfat") {

--- a/fs/Exfat.cpp
+++ b/fs/Exfat.cpp
@@ -47,7 +47,8 @@ status_t Check(const std::string& source) {
     cmd.push_back(kFsckPath);
     cmd.push_back(source);
 
-    return ForkExecvp(cmd, sFsckContext);
+    // Exfat devices are currently always untrusted
+    return ForkExecvp(cmd, sFsckUntrustedContext);
 }
 
 status_t Mount(const std::string& source, const std::string& target, bool ro,

--- a/fs/Ext4.cpp
+++ b/fs/Ext4.cpp
@@ -64,7 +64,7 @@ bool IsSupported() {
             && IsFilesystemSupported("ext4");
 }
 
-status_t Check(const std::string& source, const std::string& target) {
+status_t Check(const std::string& source, const std::string& target, bool trusted) {
     // The following is shamelessly borrowed from fs_mgr.c, so it should be
     // kept in sync with any changes over there.
 
@@ -119,8 +119,7 @@ status_t Check(const std::string& source, const std::string& target) {
         cmd.push_back("-y");
         cmd.push_back(c_source);
 
-        // ext4 devices are currently always trusted
-        return ForkExecvp(cmd, sFsckContext);
+        return ForkExecvp(cmd, trusted ? sFsckContext : sFsckUntrustedContext);
     }
 
     return 0;

--- a/fs/Ext4.h
+++ b/fs/Ext4.h
@@ -27,7 +27,7 @@ namespace ext4 {
 
 bool IsSupported();
 
-status_t Check(const std::string& source, const std::string& target);
+status_t Check(const std::string& source, const std::string& target, bool trusted);
 status_t Mount(const std::string& source, const std::string& target, bool ro,
         bool remount, bool executable);
 status_t Format(const std::string& source, unsigned long numSectors,

--- a/fs/F2fs.cpp
+++ b/fs/F2fs.cpp
@@ -40,14 +40,13 @@ bool IsSupported() {
             && IsFilesystemSupported("f2fs");
 }
 
-status_t Check(const std::string& source) {
+status_t Check(const std::string& source, bool trusted) {
     std::vector<std::string> cmd;
     cmd.push_back(kFsckPath);
     cmd.push_back("-a");
     cmd.push_back(source);
 
-    // f2fs devices are currently always trusted
-    return ForkExecvp(cmd, sFsckContext);
+    return ForkExecvp(cmd, trusted ? sFsckContext : sFsckUntrustedContext);
 }
 
 status_t Mount(const std::string& source, const std::string& target) {

--- a/fs/F2fs.h
+++ b/fs/F2fs.h
@@ -27,7 +27,7 @@ namespace f2fs {
 
 bool IsSupported();
 
-status_t Check(const std::string& source);
+status_t Check(const std::string& source, bool trusted);
 status_t Mount(const std::string& source, const std::string& target);
 status_t Format(const std::string& source);
 

--- a/fs/Ntfs.cpp
+++ b/fs/Ntfs.cpp
@@ -48,7 +48,8 @@ status_t Check(const std::string& source) {
     cmd.push_back("-n");
     cmd.push_back(source);
 
-    return ForkExecvp(cmd, sFsckContext);
+    // Ntfs devices are currently always untrusted
+    return ForkExecvp(cmd, sFsckUntrustedContext);
 }
 
 status_t Mount(const std::string& source, const std::string& target, bool ro,


### PR DESCRIPTION
* Fsck was hitting a neverallow on public volumes not formatted in vfat
  because it was always using the trusted context
* Always run trusted fsck for private volumes and untrusted for public
* Exfat/ntfs are always untrusted, because they are not supported for
  private volumes, like vfat

Change-Id: I0a6ee9aea907bae9ed097b920df0559df7b45d7d

[daedroza]: This fixes the public file system check;
07-02 14:12:13.990   201   206 E vold    : public:179,65 failed filesystem check
Probably related to some specfic SDCards (Samsung Class 6 in my case), SanDisk works fine.