### PR TITLE
AlarmService : Change stopSelf into stopSelfResult

### DIFF
--- a/src/com/android/deskclock/alarms/AlarmService.java
+++ b/src/com/android/deskclock/alarms/AlarmService.java
@@ -241,7 +241,7 @@ public class AlarmService extends Service {
                     break;
                 }
                 stopCurrentAlarm();
-                stopSelf();
+                stopSelfResult(startId);
         }
 
         return Service.START_NOT_STICKY;


### PR DESCRIPTION
Change stopSelf into stopSelfResult to avoid stopping alarm which need
to be started.

If stopAlarm is called when there is no alarm being started and then
startAlarm is called after stopAlarm, it is possibe that the started
alarm is stopped by the previous stopAlarm calling as onDestroy will
be called when stopAlarm.

Use stopSelfResult if the startId matches the last start request then
the service will be stopped.

Change-Id: I50482a471b50537c2670cfc8220aef29c5214a3c
CRs-Fixed: 1101808