### PR TITLE
Grant platform apps access to /mnt/media_rw with sdcard_posix label

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -95,6 +95,7 @@ $(sepolicy_policy.conf): $(call build_policy, $(sepolicy_build_files))
 	$(hide) m4 $(PRIVATE_ADDITIONAL_M4DEFS) \
 		-D mls_num_sens=$(PRIVATE_MLS_SENS) -D mls_num_cats=$(PRIVATE_MLS_CATS) \
 		-D target_build_variant=$(TARGET_BUILD_VARIANT) \
+		-D target_needs_platform_text_relocations=$(TARGET_NEEDS_PLATFORM_TEXT_RELOCATIONS) \
 		-s $^ > $@
 	$(hide) sed '/dontaudit/d' $@ > $@.dontaudit
 
@@ -134,6 +135,7 @@ $(sepolicy_policy_recovery.conf): $(call build_policy, $(sepolicy_build_files))
 		-D mls_num_sens=$(PRIVATE_MLS_SENS) -D mls_num_cats=$(PRIVATE_MLS_CATS) \
 		-D target_build_variant=$(TARGET_BUILD_VARIANT) \
 		-D target_recovery=true \
+		-D target_needs_platform_text_relocations=$(TARGET_NEEDS_PLATFORM_TEXT_RELOCATIONS) \
 		-s $^ > $@
 
 $(LOCAL_BUILT_MODULE): $(sepolicy_policy_recovery.conf) $(HOST_OUT_EXECUTABLES)/checkpolicy $(HOST_OUT_EXECUTABLES)/sepolicy-analyze

--- a/Android.mk
+++ b/Android.mk
@@ -95,6 +95,7 @@ $(sepolicy_policy.conf): $(call build_policy, $(sepolicy_build_files))
 	$(hide) m4 $(PRIVATE_ADDITIONAL_M4DEFS) \
 		-D mls_num_sens=$(PRIVATE_MLS_SENS) -D mls_num_cats=$(PRIVATE_MLS_CATS) \
 		-D target_build_variant=$(TARGET_BUILD_VARIANT) \
+		-D target_has_legacy_camera_hal1=$(TARGET_HAS_LEGACY_CAMERA_HAL1) \
 		-D target_needs_platform_text_relocations=$(TARGET_NEEDS_PLATFORM_TEXT_RELOCATIONS) \
 		-s $^ > $@
 	$(hide) sed '/dontaudit/d' $@ > $@.dontaudit

--- a/app.te
+++ b/app.te
@@ -194,6 +194,8 @@ allow appdomain sdcardfs:file create_file_perms;
 # File write access allowed for FDs returned through Storage Access Framework
 allow appdomain vfat:dir r_dir_perms;
 allow appdomain vfat:file rw_file_perms;
+allow appdomain sdcard_posix:dir r_dir_perms;
+allow appdomain sdcard_posix:file rw_file_perms;
 
 # Allow apps to use the USB Accessory interface.
 # http://developer.android.com/guide/topics/connectivity/usb/accessory.html

--- a/app.te
+++ b/app.te
@@ -197,6 +197,11 @@ allow appdomain vfat:file rw_file_perms;
 allow appdomain sdcard_posix:dir r_dir_perms;
 allow appdomain sdcard_posix:file rw_file_perms;
 
+# Access OBBs (sdcard_posix) mounted by vold
+# File write access allowed for FDs returned through Storage Access Framework
+allow appdomain sdcard_posix:dir r_dir_perms;
+allow appdomain sdcard_posix:file rw_file_perms;
+
 # Allow apps to use the USB Accessory interface.
 # http://developer.android.com/guide/topics/connectivity/usb/accessory.html
 #

--- a/attributes
+++ b/attributes
@@ -113,3 +113,6 @@ attribute boot_control_hal;
 # postinstall. This includes the background daemon and the sideload tool from
 # recovery for A/B devices.
 attribute update_engine_common;
+
+# Domain type used for debugfs access by QCOM
+attribute qti_debugfs_domain;

--- a/domain.te
+++ b/domain.te
@@ -323,7 +323,7 @@ neverallow * rootfs:file { create write setattr relabelto append unlink link ren
 
 # Restrict context mounts to specific types marked with
 # the contextmount_type attribute.
-neverallow * {fs_type -contextmount_type}:filesystem relabelto;
+neverallow * {fs_type -contextmount_type -sdcard_posix}:filesystem relabelto;
 
 # Ensure that context mount types are not writable, to ensure that
 # the write to /system restriction above is not bypassed via context=

--- a/domain.te
+++ b/domain.te
@@ -428,13 +428,24 @@ neverallow { domain userdebug_or_eng(`-dumpstate -shell -su') } su_exec:file no_
 # The only exceptions are for NDK text relocations associated with
 # https://code.google.com/p/android/issues/detail?id=23203
 # which, long term, need to go away.
-neverallow * {
-  file_type
-  -system_data_file
-  -apk_data_file
-  -app_data_file
-  -asec_public_file
-}:file execmod;
+ifelse(target_needs_platform_text_relocations, `true',
+  `neverallow * {
+    file_type
+    -system_file
+    -system_data_file
+    -apk_data_file
+    -app_data_file
+    -asec_public_file
+  }:file execmod;'
+,
+  `neverallow * {
+    file_type
+    -system_data_file
+    -apk_data_file
+    -app_data_file
+    -asec_public_file
+  }:file execmod;'
+)
 
 # Do not allow making the stack or heap executable.
 # We would also like to minimize execmem but it seems to be
@@ -443,7 +454,9 @@ neverallow * self:process { execstack execheap };
 
 # prohibit non-zygote spawned processes from using shared libraries
 # with text relocations. b/20013628 .
-neverallow { domain -appdomain } file_type:file execmod;
+ifelse(target_needs_platform_text_relocations, `true', ,
+  `neverallow { domain -appdomain } file_type:file execmod;'
+)
 
 neverallow { domain -init } proc:{ file dir } mounton;
 

--- a/domain.te
+++ b/domain.te
@@ -498,6 +498,7 @@ neverallow {
   -init
   -runas
   -zygote
+  userdebug_or_eng(`-qti-testscripts')
 } shell:process { transition dyntransition };
 
 # Only domains spawned from zygote and runas may have the appdomain attribute.

--- a/domain.te
+++ b/domain.te
@@ -498,12 +498,11 @@ neverallow {
   -init
   -runas
   -zygote
-  userdebug_or_eng(`-qti-testscripts')
 } shell:process { transition dyntransition };
 
 # Only domains spawned from zygote and runas may have the appdomain attribute.
 neverallow { domain -runas -zygote -adbd -init } {
-  appdomain -shell userdebug_or_eng(`-su') -bluetooth
+  appdomain -shell userdebug_or_eng(`-su') -bluetooth userdebug_or_eng(`-qti-testscripts')
 }:process { transition dyntransition };
 
 # Minimize read access to shell- or app-writable symlinks.

--- a/domain.te
+++ b/domain.te
@@ -501,7 +501,7 @@ neverallow {
 } shell:process { transition dyntransition };
 
 # Only domains spawned from zygote and runas may have the appdomain attribute.
-neverallow { domain -runas -zygote } {
+neverallow { domain -runas -zygote -adbd -init } {
   appdomain -shell userdebug_or_eng(`-su') -bluetooth
 }:process { transition dyntransition };
 

--- a/domain.te
+++ b/domain.te
@@ -583,7 +583,7 @@ neverallow * domain:file { execute execute_no_trans entrypoint };
 # Instead, if access to part of debugfs is desired, it should have a
 # more specific label.
 # TODO: fix system_server and dumpstate
-neverallow { domain -init -system_server -dumpstate } debugfs:file no_rw_file_perms;
+neverallow { domain -init -system_server -dumpstate userdebug_or_eng(`-qti_debugfs_domain')} debugfs:file no_rw_file_perms;
 
 neverallow {
   domain

--- a/file.te
+++ b/file.te
@@ -48,6 +48,7 @@ type shm, fs_type;
 type mqueue, fs_type;
 type fuse, sdcard_type, fs_type, mlstrustedobject;
 type sdcardfs, sdcard_type, fs_type, mlstrustedobject;
+type sdcard_posix, sdcard_type, fs_type, mlstrustedobject;
 type vfat, sdcard_type, fs_type, mlstrustedobject;
 type debugfs, fs_type;
 type debugfs_trace_marker, fs_type, debugfs_type, mlstrustedobject;

--- a/mediaserver.te
+++ b/mediaserver.te
@@ -94,6 +94,12 @@ allow mediaserver processinfo_service:service_manager find;
 allow mediaserver scheduling_policy_service:service_manager find;
 allow mediaserver surfaceflinger_service:service_manager find;
 
+ifelse(target_has_legacy_camera_hal1, `true',
+  allow mediaserver cameraproxy_service:service_manager find;
+  allow mediaserver cameraserver_service:service_manager add;
+,
+)
+
 # /oem access
 allow mediaserver oemfs:dir search;
 allow mediaserver oemfs:file r_file_perms;

--- a/platform_app.te
+++ b/platform_app.te
@@ -39,6 +39,11 @@ allow platform_app mnt_media_rw_file:dir r_dir_perms;
 allow platform_app vfat:dir create_dir_perms;
 allow platform_app vfat:file create_file_perms;
 
+# Direct access to vold-mounted storage under /mnt/media_rw
+# This is a performance optimization that allows platform apps to bypass the FUSE layer
+allow platform_app sdcard_posix:dir create_dir_perms;
+allow platform_app sdcard_posix:file create_file_perms;
+
 allow platform_app audioserver_service:service_manager find;
 allow platform_app cameraserver_service:service_manager find;
 allow platform_app drmserver_service:service_manager find;

--- a/qti-testscripts.te
+++ b/qti-testscripts.te
@@ -1,0 +1,3 @@
+userdebug_or_eng(`
+  type qti-testscripts, domain, domain_deprecated, mlstrustedsubject;
+')

--- a/system_server.te
+++ b/system_server.te
@@ -54,15 +54,12 @@ allow system_server self:capability {
     net_raw
     sys_boot
     sys_nice
-    sys_resource
+    sys_ptrace
     sys_time
     sys_tty_config
 };
 
 wakelock_use(system_server)
-
-# Triggered by /proc/pid accesses, not allowed.
-dontaudit system_server self:capability sys_ptrace;
 
 # Trigger module auto-load.
 allow system_server kernel:system module_request;

--- a/vold.te
+++ b/vold.te
@@ -41,6 +41,7 @@ allow vold devpts:chr_file rw_file_perms;
 allow vold rootfs:dir mounton;
 allow vold sdcard_type:dir mounton; # TODO: deprecated in M
 allow vold sdcard_type:filesystem { mount remount unmount }; # TODO: deprecated in M
+allow vold sdcard_posix:filesystem { relabelto relabelfrom };
 allow vold sdcard_type:dir create_dir_perms; # TODO: deprecated in M
 allow vold sdcard_type:file create_file_perms; # TODO: deprecated in M
 

--- a/vold.te
+++ b/vold.te
@@ -42,6 +42,7 @@ allow vold rootfs:dir mounton;
 allow vold sdcard_type:dir mounton; # TODO: deprecated in M
 allow vold sdcard_type:filesystem { mount remount unmount }; # TODO: deprecated in M
 allow vold sdcard_posix:filesystem { relabelto relabelfrom };
+allow vold labeledfs:filesystem { relabelfrom };
 allow vold sdcard_type:dir create_dir_perms; # TODO: deprecated in M
 allow vold sdcard_type:file create_file_perms; # TODO: deprecated in M
 


### PR DESCRIPTION
Also allow apps to read the contents of mounted OBBs.

See AOSP Change-Id: I66df236eade3ca25a10749dd43d173ff4628cfad
and Change-Id: I49b722b24c1c7d9ab084ebee7c1e349d8d660ffa

Change-Id: I757a2a8831c69d41c0496025a39eaf79ceb0e65f